### PR TITLE
CI/GitHub release

### DIFF
--- a/.github/workflows/joint-publish-extension.yaml
+++ b/.github/workflows/joint-publish-extension.yaml
@@ -2,8 +2,6 @@ name: Publish Extension
 
 on:
   push:
-    branches:
-      - "main"
     tags:
       - "*v"
 

--- a/.github/workflows/joint-publish-extension.yaml
+++ b/.github/workflows/joint-publish-extension.yaml
@@ -16,12 +16,24 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
+
       - name: Publish to Open VSX Registry
+        id: publishToOpenVSX
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.OPEN_VSX_PAT }}
+
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
+          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+
+      - name: GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          name: ${{ github.ref_name }}
+          fail_on_unmatched_files: true
+          files: ${{ steps.publishToOpenVSX.outputs.vsixPath }}


### PR DESCRIPTION
Add a workflow step to automatically create a GitHub Release upon creation of a new tag.